### PR TITLE
Feature improve shutdown behavior. Closes https://github.com/Supervisor/supervisor/issues/1101

### DIFF
--- a/supervisor/options.py
+++ b/supervisor/options.py
@@ -1068,8 +1068,8 @@ class ServerOptions(Options):
                 exitcodes=exitcodes,
                 redirect_stderr=redirect_stderr,
                 environment=environment,
-                serverurl=serverurl)
-                disable_force_shutdown=disable_force_shutdown,
+                serverurl=serverurl,
+                disable_force_shutdown=disable_force_shutdown)
 
             programs.append(pconfig)
 
@@ -1889,8 +1889,8 @@ class ProcessConfig(Config):
         'stderr_logfile_backups', 'stderr_logfile_maxbytes',
         'stderr_events_enabled', 'stderr_syslog',
         'stopsignal', 'stopwaitsecs', 'stopasgroup', 'killasgroup',
-        'exitcodes', 'redirect_stderr', 'disable_force_shutdown' ]
-    optional_param_names = [ 'environment', 'serverurl' ]
+        'exitcodes', 'redirect_stderr']
+    optional_param_names = [ 'environment', 'serverurl', 'disable_force_shutdown']
 
     def __init__(self, options, **params):
         self.options = options

--- a/supervisor/options.py
+++ b/supervisor/options.py
@@ -942,6 +942,7 @@ class ServerOptions(Options):
         serverurl = get(section, 'serverurl', None)
         if serverurl and serverurl.strip().upper() == 'AUTO':
             serverurl = None
+        disable_force_shutdown  = get(section, 'disable_force_shutdown', False)
 
         # find uid from "user" option
         user = get(section, 'user', None)

--- a/supervisor/options.py
+++ b/supervisor/options.py
@@ -1069,6 +1069,7 @@ class ServerOptions(Options):
                 redirect_stderr=redirect_stderr,
                 environment=environment,
                 serverurl=serverurl)
+                disable_force_shutdown=disable_force_shutdown,
 
             programs.append(pconfig)
 
@@ -1888,7 +1889,7 @@ class ProcessConfig(Config):
         'stderr_logfile_backups', 'stderr_logfile_maxbytes',
         'stderr_events_enabled', 'stderr_syslog',
         'stopsignal', 'stopwaitsecs', 'stopasgroup', 'killasgroup',
-        'exitcodes', 'redirect_stderr' ]
+        'exitcodes', 'redirect_stderr', 'disable_force_shutdown' ]
     optional_param_names = [ 'environment', 'serverurl' ]
 
     def __init__(self, options, **params):

--- a/supervisor/process.py
+++ b/supervisor/process.py
@@ -5,6 +5,7 @@ import signal
 import shlex
 import time
 import traceback
+import psutil
 
 from supervisor.compat import maxint
 from supervisor.compat import as_bytes
@@ -464,6 +465,11 @@ class Subprocess(object):
 
         try:
             try:
+                # make sure all child processes are properly stopped as well
+                parent = psutil.Process(abs(pid))
+                for child in parent.children(recursive=True):  # or parent.children() for recursive=False
+                    # kill child processes with same signal as parent
+                    options.kill(child.pid, sig)
                 options.kill(pid, sig)
             except OSError as exc:
                 if exc.errno == errno.ESRCH:

--- a/supervisor/rpcinterface.py
+++ b/supervisor/rpcinterface.py
@@ -411,7 +411,10 @@ class SupervisorNamespaceRPCInterface:
         if process.get_state() not in RUNNING_STATES:
             raise RPCError(Faults.NOT_RUNNING, name)
 
-        msg = process.stop(self.supervisord)
+        try:
+            msg = process.stop(self.supervisord)
+        except:
+            msg = process.stop()
         if msg is not None:
             raise RPCError(Faults.FAILED, msg)
 

--- a/supervisor/rpcinterface.py
+++ b/supervisor/rpcinterface.py
@@ -411,7 +411,7 @@ class SupervisorNamespaceRPCInterface:
         if process.get_state() not in RUNNING_STATES:
             raise RPCError(Faults.NOT_RUNNING, name)
 
-        msg = process.stop()
+        msg = process.stop(self.supervisord)
         if msg is not None:
             raise RPCError(Faults.FAILED, msg)
 

--- a/supervisor/supervisord.py
+++ b/supervisor/supervisord.py
@@ -34,6 +34,7 @@ Options:
 import os
 import time
 import signal
+import psutil
 
 from supervisor.medusa import asyncore_25 as asyncore
 
@@ -55,6 +56,7 @@ class Supervisor:
         self.options = options
         self.process_groups = {}
         self.ticks = {}
+        self.terminated_processes = []
 
     def main(self):
         if not self.options.first:
@@ -156,7 +158,7 @@ class Supervisor:
     def ordered_stop_groups_phase_1(self):
         if self.stop_groups:
             # stop the last group (the one with the "highest" priority)
-            self.stop_groups[-1].stop_all()
+            self.stop_groups[-1].stop_all(supervisor=self)
 
     def ordered_stop_groups_phase_2(self):
         # after phase 1 we've transitioned and reaped, let's see if we
@@ -196,9 +198,12 @@ class Supervisor:
                 self.ordered_stop_groups_phase_1()
 
                 if not self.shutdown_report():
-                    # if there are no unstopped processes (we're done
-                    # killing everything), it's OK to shutdown or reload
-                    raise asyncore.ExitNow
+                    # make sure all processes are properly terminated
+                    self.kill_process_after_reaching_timeout()
+                    if not self.terminated_processes:
+                        # if there are no unstopped processes (we're done
+                        # killing everything), it's OK to shutdown or reload
+                        raise asyncore.ExitNow
 
             for fd, dispatcher in combined_map.items():
                 if dispatcher.readable():
@@ -241,6 +246,7 @@ class Supervisor:
             for group in pgroups:
                 group.transition()
 
+            self.kill_process_after_reaching_timeout()
             self.reap()
             self.handle_signal()
             self.tick()
@@ -315,6 +321,23 @@ class Supervisor:
 
     def get_state(self):
         return self.options.mood
+
+    def kill_process_after_reaching_timeout(self, timeout=60):
+        """
+        Iterate over list of previously terminated processes and check if they
+        are still alive. Send SIGKILL to all processes which are not not
+        properly shutdown before the timeout is reached.
+        """
+        if self.terminated_processes:
+            current_time = time.time()
+            for pid, terminate_time in self.terminated_processes:
+                if psutil.pid_exists(pid):
+                    if current_time - terminate_time > timeout:
+                        # Send SIGKILL if process does not terminate succesfully
+                        os.kill(pid, signal.SIGKILL)
+                        self.terminated_processes.remove((pid, terminate_time))
+                else:
+                    self.terminated_processes.remove((pid, terminate_time))
 
 def timeslice(period, when):
     return int(when - (when % period))

--- a/supervisor/tests/base.py
+++ b/supervisor/tests/base.py
@@ -434,7 +434,7 @@ class DummyProcess(object):
     def get_state(self):
         return self.state
 
-    def stop(self):
+    def stop(self, supervisor=None):
         self.stop_called = True
         self.killing = False
         from supervisor.process import ProcessStates
@@ -443,7 +443,7 @@ class DummyProcess(object):
     def stop_report(self):
         self.stop_report_called = True
 
-    def kill(self, signal):
+    def kill(self, signal, supervisor=None):
         self.killed_with = signal
 
     def signal(self, signal):
@@ -517,7 +517,7 @@ class DummyPConfig:
                  stderr_syslog=False,
                  redirect_stderr=False,
                  stopsignal=None, stopwaitsecs=10, stopasgroup=False, killasgroup=False,
-                 exitcodes=(0,), environment=None, serverurl=None):
+                 exitcodes=(0,), environment=None, serverurl=None, disable_force_shutdown=False):
         self.options = options
         self.name = name
         self.command = command
@@ -553,6 +553,7 @@ class DummyPConfig:
         self.umask = umask
         self.autochildlogs_created = False
         self.serverurl = serverurl
+        self.disable_force_shutdown = disable_force_shutdown
 
     def get_path(self):
         return ["/bin", "/usr/bin", "/usr/local/bin"]
@@ -1049,7 +1050,7 @@ class DummyProcessGroup(object):
     def before_remove(self):
         self.before_remove_called = True
 
-    def stop_all(self):
+    def stop_all(self, supervisor=None):
         self.all_stopped = True
 
     def get_unstopped_processes(self):

--- a/tox.ini
+++ b/tox.ini
@@ -8,6 +8,7 @@ deps =
     pytest
     pexpect == 4.7.0  # see https://github.com/Supervisor/supervisor/issues/1327
     mock >= 0.5.0
+    psutil == 5.9.0
 passenv = END_TO_END
 commands =
     pytest {posargs}


### PR DESCRIPTION
**Use Case/ Context**
Stopping a process via CLI or supervisor UI should stop the process and all it's child processes reliable. If the processes refuse to stop (e.g. not reacting to signals), they need to be forcefully stopped after some timeout. Additionally only direct child's of supervisor are properly stopped. Grandchild processes are not properly stopped and net be signaled as well.

**Current Behavior**
Supervisor handles different signals as stated here: http://supervisord.org/running.html#signals When a TERM, INT or QUIT signal is received, supervisor will trigger the shutdown behavior. This signals can also be sent to the process group, but not all processes started from a program are necessarily in the same process group, as mentioned here: https://github.com/Supervisor/supervisor/pull/199#issuecomment-132838482. Supervisor only knows about the direct child processes that it started but not any processes which any of the child processes spawned.

**Possible Solution:**
This stopping behavior still needs some improvements.
Stopping a process  and all it's child processes reliable also needs a check if the processes are actually stopped and if the processes refuse to stop (e.g. not reacting to signals), they need to be forcefully stopped after some timeout via SIGKILL signal. There are a couple of things to consider:

* think about a good timeout. Systemd uses about 2-3 mins, for my use-cases 60 seconds should be sufficient.
* SIGKILL can be very intrusive. For example when processes are killed which are doing some operations on a database, this can cause loss of data.
* There should be an additional config parameter such as `disable_force_shutdown_behavior` which would disable the mechanism of sending SIGKILL to the process and its childs.

We should define our usual behavior and allow users to alter this behavior. What's sensible is a default behavior -- I would say a round of SIGTERM to children, and after some time sending a SIGKILL to those who still alive is the ideal solution.

Note, however, that sometimes process can "hang" in the kernel (or as they call it D-state, see ps man page). It's rare in a healthy system, but still possible. For those situation, I would say we should report it to the user somehow.
